### PR TITLE
[37] - Configura Hot Deploy no spring boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,4 +61,11 @@ dependencies {
 	compile 'org.springframework.security:spring-security-web'
 	compile 'org.springframework.security:spring-security-config'
 	compile 'io.jsonwebtoken:jjwt:0.6.0'
+	compile 'org.springframework.boot:spring-boot-devtools'
+}
+
+task(runDebug, dependsOn: 'classes', type: JavaExec) {
+    main = 'com.hades.HadesApplication'
+    classpath = sourceSets.main.runtimeClasspath
+    jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=9999"]
 }


### PR DESCRIPTION
@ericdallo

Foi adicionado a task ``runDebug`` ao gradle...onde o server é iniciado e configurado uma porta(9999) para debug remoto.

### TO TEST
``gradle runDebug``

No eclipse, ir em ``Preferences`` --> ``Remote Java Application`` e configurar o debug na porta 9999.
![screenshot from 2016-04-03 17-46-01](https://cloud.githubusercontent.com/assets/7820865/14235141/e9747a66-f9cb-11e5-9391-c1e1232cc35e.png)
![screenshot from 2016-04-03 17-46-25](https://cloud.githubusercontent.com/assets/7820865/14235140/e9737710-f9cb-11e5-8ed3-876a927df61d.png)
![screenshot from 2016-04-03 17-46-35](https://cloud.githubusercontent.com/assets/7820865/14235142/e9751fca-f9cb-11e5-85ac-ae7656dfec76.png)


Após a configuração, escolher Debug,(é possivel configurar atalhos para linkar a sessao automaticamente)

Foi habilitado tambem o Hot Swap, onde ao alterar no eclipse o codigo, __menos assinatura de classes e métodos,__ rapidamente já é alterado os ``.class`` da aplicação